### PR TITLE
Remove testing older functionalities from CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,6 @@ install(FILES ${CPACK_RESOURCE_FILE_LICENSE} DESTINATION ${CMAKE_INSTALL_DOCDIR}
 
 enable_testing()
 include(CTest)
-add_subdirectory(utilities/rpp-unittests) # TBD - phaseout unittests
 add_subdirectory(utilities/test_suite) # TBD - Expand use-cases
 
 # Set package information
@@ -457,7 +456,7 @@ include(CPack)
 cpack_add_component(runtime
    DISPLAY_NAME "RPP Runtime Package"
    DESCRIPTION "ROCm Performance Primitives library is a comprehensive high performance \
-computer vision library for AMD CPUs and GPUs with HOST/HIP/OpenCL back-ends. 
+computer vision library for AMD CPUs and GPUs with HOST/HIP/OpenCL back-ends.
 RPP runtime package provides rpp library and license.txt")
 
 cpack_add_component(dev
@@ -468,6 +467,6 @@ RPP develop package provides rpp library, header files, and license.txt")
 
 cpack_add_component(asan
     DISPLAY_NAME "RPP ASAN Package"
-    DESCRIPTION "ROCm Performance Primitives library is a comprehensive high performance \ 
+    DESCRIPTION "ROCm Performance Primitives library is a comprehensive high performance \
 computer vision library for AMD CPUs and GPUs with HOST/HIP/OpenCL back-ends. \
 RPP ASAN package provides rpp ASAN libraries")

--- a/utilities/test_suite/CMakeLists.txt
+++ b/utilities/test_suite/CMakeLists.txt
@@ -58,25 +58,26 @@ if(Python3_FOUND)
     endif(libsnd_LIBS)
 
     # Running case by case - one sample for brightness (in tensor_host) + one sample for slice (in tensor_voxel_host) + one sample for non_silent_region (in tensor_audio_host)
-    add_test(
-        NAME rpp_qa_tests_tensor_host_brightness
-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HOST/runTests.py --qa_mode 1 --batch_size 3 --case_list 0
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    if(NIFTI_FOUND)
-        add_test(
-            NAME rpp_qa_tests_tensor_voxel_host_slice
-            COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HOST/runTests_voxel.py --qa_mode 1 --batch_size 3 --case_list 1
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        )
-    endif(NIFTI_FOUND)
-    if(libsnd_LIBS)
-        add_test(
-            NAME rpp_qa_tests_tensor_audio_host_non_silent_region
-            COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HOST/runAudioTests.py --case_list 0 --qa_mode 1 --batch_size 3
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        )
-    endif(libsnd_LIBS)
+    # TBD: Add each functionality test separately below, and comment/remove "_all" type testing above
+    # add_test(
+    #     NAME rpp_qa_tests_tensor_host_brightness
+    #     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HOST/runTests.py --qa_mode 1 --batch_size 3 --case_list 0
+    #     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    # )
+    # if(NIFTI_FOUND)
+    #     add_test(
+    #         NAME rpp_qa_tests_tensor_voxel_host_slice
+    #         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HOST/runTests_voxel.py --qa_mode 1 --batch_size 3 --case_list 1
+    #         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    #     )
+    # endif(NIFTI_FOUND)
+    # if(libsnd_LIBS)
+    #     add_test(
+    #         NAME rpp_qa_tests_tensor_audio_host_non_silent_region
+    #         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HOST/runAudioTests.py --case_list 0 --qa_mode 1 --batch_size 3
+    #         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    #     )
+    # endif(libsnd_LIBS)
 
     if( "${BACKEND}" STREQUAL "HIP")
 
@@ -95,19 +96,20 @@ if(Python3_FOUND)
         endif(NIFTI_FOUND)
 
         # Running case by case - one sample for brightness (in tensor_hip) and one sample for slice (in tensor_voxel_hip)
-        add_test(
-            NAME rpp_qa_tests_tensor_hip_brightness
-            COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HIP/runTests.py --qa_mode 1 --batch_size 3 --case_list 0
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        )
-        if(NIFTI_FOUND)
-            add_test(
-                NAME rpp_qa_tests_tensor_voxel_hip_slice
-                COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HIP/runTests_voxel.py --qa_mode 1 --batch_size 3 --case_list 1
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-        endif(NIFTI_FOUND)
-    
+        # TBD: Add each functionality test separately below, and comment/remove "_all" type testing above
+        # add_test(
+        #     NAME rpp_qa_tests_tensor_hip_brightness
+        #     COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HIP/runTests.py --qa_mode 1 --batch_size 3 --case_list 0
+        #     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        # )
+        # if(NIFTI_FOUND)
+        #     add_test(
+        #         NAME rpp_qa_tests_tensor_voxel_hip_slice
+        #         COMMAND ${Python3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/utilities/test_suite/HIP/runTests_voxel.py --qa_mode 1 --batch_size 3 --case_list 1
+        #         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        #     )
+        # endif(NIFTI_FOUND)
+
     elseif( "${BACKEND}" STREQUAL "OCL")
         # TBD: Add OCL Tests
 


### PR DESCRIPTION
@kiritigowda This is a minor PR that removes the original rpp-unittests tests that were added.
And commenting out the repetitive independent tests that were running even after testing "all".
I have added a comment stating that once we add individual tests in the cmake, the "all" style can be commented and independent ones used.