### PR TITLE
Update doc codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-# Documentation files
-docs/* @saadrahim @LisaDelaney
-*.md  @saadrahim @LisaDelaney
-*.rst  @saadrahim @LisaDelaney
-# Header directory
-library/include/*  @saadrahim @LisaDelaney @kiritigowda @rrawther
 # Source code
 @kiritigowda @rrawther
+# Documentation files
+docs/* @ROCm/rocm-documentation
+*.md @ROCm/rocm-documentation
+*.rst @ROCm/rocm-documentation
+# Header directory
+library/include/* @ROCm/rocm-documentation @kiritigowda @rrawther


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2833
Adding documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes.

Please note that this requires the team to be added as a role with Write permissions.