### PR TITLE
Add the ROCm version for each rpp release in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/rpp/en/latest](https://rocm.docs.amd.com/projects/rpp/en/latest)
 
-## RPP 1.8.0 (Unreleased)
+## (Unreleased) RPP 1.8.0
 
 ### Changes
 
@@ -25,7 +25,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * CMake - Version `3.22.3`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-### RPP 1.5.0
+### RPP 1.5.0 for ROCm 6.1.1
 
 ### Changes
 
@@ -42,7 +42,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * CMake - Version `3.22.3`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-## RPP 1.4.0
+## RPP 1.4.0 for ROCm 6.0.0
 
 ### Additions
 
@@ -76,7 +76,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * CMake - Version `3.22.3`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-## RPP 1.3.0
+## RPP 1.3.0 for ROCm 5.7.1
 
 ### Additions
 
@@ -106,7 +106,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * Boost - Version `1.72`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-## RPP 1.2.0
+## RPP 1.2.0 for ROCm 5.7.1
 
 ### Additions
 
@@ -137,7 +137,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * Boost - Version `1.72`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-## RPP 1.1.0
+## RPP 1.1.0 for ROCm 5.7.0
 
 ### Additions
 
@@ -172,7 +172,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * SLES - the Clang package is missing in the latest updates, which means Clang must be manually
   installed.
 
-## RPP 1.0.0
+## RPP 1.0.0 for ROCm 5.7.0
 
 ### Additions
 
@@ -212,7 +212,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * SLES - the Clang package is missing in the latest updates, which means Clang must be manually
   installed.
 
-## RPP 0.99
+## RPP 0.99 for ROCm 5.7.0
 
 ### Additions
 
@@ -241,7 +241,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * Boost - Version `1.72`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-## RPP 0.98
+## RPP 0.98 for ROCm 5.7.0
 
 ### Additions
 * Dockers
@@ -270,7 +270,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * Boost - Version `1.72`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-## RPP 0.97
+## RPP 0.97 for ROCm 5.7.0
 
 ### Additions
 
@@ -301,7 +301,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 * Boost - Version `1.72`
 * IEEE 754-based half-precision floating-point library - Version `1.12.0`
 
-## RPP 0.96
+## RPP 0.96 for ROCm 5.7.0
 
 ### Additions
 
@@ -334,7 +334,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 
 * RPP is not supported on CentOS 7 and SLES SP2
 
-## RPP 0.95
+## RPP 0.95 for ROCm 5.7.0
 
 ### Additions
 
@@ -368,7 +368,7 @@ Full documentation for RPP is available at [https://rocm.docs.amd.com/projects/r
 
 * ROCm reorganization: install updates no longer match ROCm specifications
 
-## RPP 0.93
+## RPP 0.93 for ROCm 5.7.0
 
 ### Additions
 


### PR DESCRIPTION
Based on the CMakeLists.txt for each release branch (eg: https://github.com/ROCm/rpp/blob/release/rocm-rel-5.7/CMakeLists.txt)

Relates to https://github.com/ROCm/ROCm/issues/3431