### PR TITLE
MIVisionX compatibility fix - Resample and preemphasis filter

### DIFF
--- a/include/rpp_version.h
+++ b/include/rpp_version.h
@@ -40,7 +40,7 @@ extern "C" {
 // NOTE: Match the version with CMakelists.txt version
 #define RPP_VERSION_MAJOR 1
 #define RPP_VERSION_MINOR 9
-#define RPP_VERSION_PATCH 0
+#define RPP_VERSION_PATCH 1
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -5452,6 +5452,12 @@ inline void compute_bicubic_coefficient(Rpp32f weight, Rpp32f &coeff)
     coeff = (x >= 2) ? 0 : ((x > 1) ? (x * x * (-0.5f * x + 2.5f) - 4.0f * x + 2.0f) : (x * x * (1.5f * x - 2.5f) + 1.0f));
 }
 
+inline Rpp32f sinc(Rpp32f x)
+{
+    x *= M_PI;
+    return (std::abs(x) < 1e-5f) ? (1.0f - x * x * ONE_OVER_6) : std::sin(x) / x;
+}
+
 inline void compute_lanczos3_coefficient(Rpp32f weight, Rpp32f &coeff)
 {
     coeff = fabs(weight) >= 3 ? 0.0f : (sinc(weight) * sinc(weight * 0.333333f));

--- a/src/modules/hip/kernel/resample.hpp
+++ b/src/modules/hip/kernel/resample.hpp
@@ -66,7 +66,7 @@ __global__ void resample_single_channel_hip_tensor(float *srcPtr,
 
         // copy all values from window lookup table to shared memory lookup table
         for (int k = hipThreadIdx_x; k < window->lookupSize; k += hipBlockDim_x)
-            lookup_smem[k] = window->lookup[k];
+            lookup_smem[k] = window->lookupPinned[k];
         __syncthreads();
 
         if (outBlock >= dstLength)
@@ -177,7 +177,7 @@ __global__ void resample_multi_channel_hip_tensor(float *srcPtr,
 
         // copy all values from window lookup table to shared memory lookup table
         for (int k = hipThreadIdx_x; k < window->lookupSize; k += hipBlockDim_x)
-            lookup_smem[k] = window->lookup[k];
+            lookup_smem[k] = window->lookupPinned[k];
         __syncthreads();
 
         if (outBlock >= dstLength)

--- a/src/modules/rppt_tensor_audio_augmentations.cpp
+++ b/src/modules/rppt_tensor_audio_augmentations.cpp
@@ -114,8 +114,10 @@ RppStatus rppt_pre_emphasis_filter_host(RppPtr_t srcPtr,
                                         RpptAudioBorderType borderType,
                                         rppHandle_t rppHandle)
 {
-    if (srcDescPtr->numDims != 2)
-        return RPP_ERROR_INVALID_SRC_DIMS;
+    // Disabled this check for now. 
+    // This check will be re-enabled when the numDims based changes are added in MIVisionX */
+    // if (srcDescPtr->numDims != 2)
+    //     return RPP_ERROR_INVALID_SRC_DIMS;
 
     if ((srcDescPtr->dataType == RpptDataType::F32) && (dstDescPtr->dataType == RpptDataType::F32))
     {

--- a/utilities/test_suite/HIP/Tensor_audio_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_audio_hip.cpp
@@ -371,8 +371,8 @@ int main(int argc, char **argv)
         CHECK_RETURN_STATUS(hipHostFree(detectionLength));
     if (window != nullptr)
     {
-        if (window->lookup != nullptr)
-            CHECK_RETURN_STATUS(hipHostFree(window->lookup));
+        if (window->lookupSize)
+            CHECK_RETURN_STATUS(hipHostFree(window->lookupPinned));
         CHECK_RETURN_STATUS(hipHostFree(window));
     }
     if (inRateTensor != nullptr)

--- a/utilities/test_suite/HOST/Tensor_audio_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_audio_host.cpp
@@ -470,7 +470,6 @@ int main(int argc, char **argv)
     free(dstDims);
     free(inputf32);
     free(outputf32);
-    if (window.lookup != nullptr)
-        free(window.lookup);
+        
     return 0;
 }

--- a/utilities/test_suite/rpp_test_suite_audio.h
+++ b/utilities/test_suite/rpp_test_suite_audio.h
@@ -317,3 +317,45 @@ void verify_non_silent_region_detection(int *detectedIndex, int *detectionLength
         qaResults.close();
     }
 }
+
+inline Rpp32f sinc(Rpp32f x)
+{
+    x *= M_PI;
+    return (std::abs(x) < 1e-5f) ? (1.f - (x * x * 0.16666667)) : std::sin(x) / x;
+}
+
+inline Rpp64f hann(Rpp64f x)
+{
+    return 0.5 * (1 + std::cos(x * M_PI));
+}
+
+// initialization function used for filling the values in Resampling window (RpptResamplingWindow)
+// using the coeffs and lobes value this function generates a LUT (look up table) which is further used in Resample audio augmentation
+inline void windowed_sinc(RpptResamplingWindow &window, Rpp32s coeffs, Rpp32s lobes)
+{
+    Rpp32f scale = 2.0f * lobes / (coeffs - 1);
+    Rpp32f scale_envelope = 2.0f / coeffs;
+    window.coeffs = coeffs;
+    window.lobes = lobes;
+    window.lookupSize = coeffs + 5;
+    Rpp32s center = (coeffs - 1) * 0.5f;
+    Rpp32f *lookupPtr = nullptr;
+#ifdef GPU_SUPPORT
+    CHECK_RETURN_STATUS(hipHostMalloc(&(window.lookupPinned), window.lookupSize * sizeof(Rpp32f)));
+    lookupPtr = window.lookupPinned;
+#else
+    window.lookup.clear();
+    window.lookup.resize(window.lookupSize);
+    lookupPtr = window.lookup.data();
+#endif
+    for (int i = 0; i < coeffs; i++) {
+        Rpp32f x = (i - center) * scale;
+        Rpp32f y = (i - center) * scale_envelope;
+        Rpp32f w = sinc(x) * hann(y);
+        lookupPtr[i + 1] = w;
+    }
+    window.center = center + 1;
+    window.scale = 1 / scale;
+    window.pCenter = _mm_set1_ps(window.center);
+    window.pScale = _mm_set1_ps(window.scale);  
+}


### PR DESCRIPTION
- Move out the windowed_sinc function from rppdefs.h and readded vector usage for lookup table for compatibility
- Disable the numDims validation for preemphasis HOST kernel temporarily