### PR TITLE
Test suite build fix - Lock to specific 'nifti_clib' commit

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -17,14 +17,14 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
     }
     else if (platform.jenkinsLabel.contains('ubuntu')) {
         enableAudioTesting = 'sudo apt-get install -y libsndfile1-dev'
-        enableVoxelTesting = '(git clone https://github.com/NIFTI-Imaging/nifti_clib.git; cd nifti_clib; mkdir build; cd build; cmake ../; sudo make -j$nproc install)'
+        enableVoxelTesting = '(git clone https://github.com/NIFTI-Imaging/nifti_clib.git; cd nifti_clib; git reset --hard 84e323cc3cbb749b6a3eeef861894e444cf7d788; mkdir build; cd build; cmake ../; sudo make -j$nproc install)'
         if (platform.jenkinsLabel.contains('ubuntu20')) {
             backend = 'OCL'
         }
     }
     else if (platform.jenkinsLabel.contains('rhel')) {
         enableAudioTesting = 'sudo yum install -y libsndfile-devel'
-        enableVoxelTesting = '(git clone https://github.com/NIFTI-Imaging/nifti_clib.git; cd nifti_clib; mkdir build; cd build; cmake ../; sudo make -j$nproc install)'
+        enableVoxelTesting = '(git clone https://github.com/NIFTI-Imaging/nifti_clib.git; cd nifti_clib; git reset --hard 84e323cc3cbb749b6a3eeef861894e444cf7d788; mkdir build; cd build; cmake ../; sudo make -j$nproc install)'
     }
     
 

--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -30,10 +30,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false, boolean s
 
     def command = """#!/usr/bin/env bash
                 set -x
-                wget https://sourceforge.net/projects/half/files/half/1.12.0/half-1.12.0.zip
-                unzip half-1.12.0.zip -d half-files
-                sudo mkdir -p /usr/local/include/half
-                sudo cp half-files/include/half.hpp /usr/local/include/half
+                sudo apt install half
                 echo Build RPP - ${buildTypeDir}
                 cd ${project.paths.project_build_prefix}
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}

--- a/utilities/test_suite/README.md
+++ b/utilities/test_suite/README.md
@@ -43,6 +43,7 @@ This repository contains four test suites for the RPP library: `image`/`voxel`/`
   ```shell
   git clone https://github.com/NIFTI-Imaging/nifti_clib.git
   cd nifti_clib
+  git reset --hard 84e323cc3cbb749b6a3eeef861894e444cf7d788
   mkdir build
   cd build
   cmake ..


### PR DESCRIPTION
- Fixes test suite build by locking to specific nifti_clib commit ID - https://github.com/NIFTI-Imaging/nifti_clib/commit/84e323cc3cbb749b6a3eeef861894e444cf7d788
- Minor change to sudo apt install half in common.groovy for jenkins