### PR TITLE
Bugfixes - Test suite

### DIFF
--- a/src/modules/tensor/cpu/kernel/box_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/box_filter.cpp
@@ -1622,7 +1622,7 @@ RppStatus box_filter_float_host_tensor(T *srcPtr,
             {
                 /* exclude (2 * padLength) number of columns from alignedLength calculation
                    since padLength number of columns from the beginning and end of each row will be computed using raw c code */
-                Rpp32u alignedLength = ((bufferLength - (2 * padLength)) / 16) * 16;
+                Rpp32u alignedLength = ((bufferLength - (2 * padLength)) / 14) * 14;
                 for (int c = 0; c < srcDescPtr->c; c++)
                 {
                     srcPtrRow[0] = srcPtrChannel;

--- a/src/modules/tensor/cpu/kernel/flip.cpp
+++ b/src/modules/tensor/cpu/kernel/flip.cpp
@@ -879,7 +879,7 @@ RppStatus flip_f16_f16_host_tensor(Rpp16f *srcPtr,
                         srcPtrTemp += srcPtrIncrementPerChannel;
                         dstPtrTemp += vectorIncrementPerChannel;
                     }
-                    srcPtrTemp -= hFlipFactorPerChannel;
+                    srcPtrTemp += hFlipFactorPerChannel;
                     for (; vectorLoopCount < bufferLength; vectorLoopCount++)
                     {
                         *dstPtrTemp = (Rpp16f) RPPPIXELCHECKF32((Rpp32f)*srcPtrTemp);

--- a/src/modules/tensor/cpu/kernel/gaussian_filter.cpp
+++ b/src/modules/tensor/cpu/kernel/gaussian_filter.cpp
@@ -143,7 +143,7 @@ RppStatus gaussian_filter_host_tensor(T *srcPtr,
             {
                 /* exclude 2 * padLength number of columns from alignedLength calculation
                    since padLength number of columns from the beginning and end of each row will be computed using raw c code */
-                Rpp32u alignedLength = ((bufferLength - (2 * padLength)) / 16) * 16;
+                Rpp32u alignedLength = ((bufferLength - (2 * padLength)) / 14) * 14;
                 for (int c = 0; c < srcDescPtr->c; c++)
                 {
                     srcPtrRow[0] = srcPtrChannel;
@@ -301,7 +301,7 @@ RppStatus gaussian_filter_host_tensor(T *srcPtr,
             {
                 /* exclude (2 * padLength) number of columns from alignedLength calculation
                     since padLength number of columns from the beginning and end of each row will be computed using raw c code */
-                Rpp32u alignedLength = ((bufferLength - (2 * padLength)) / 16) * 16;
+                Rpp32u alignedLength = ((bufferLength - (2 * padLength)) / 14) * 14;
                 for(int i = 0; i < roi.xywhROI.roiHeight; i++)
                 {
                     int vectorLoopCount = 0;

--- a/src/modules/tensor/cpu/kernel/threshold.cpp
+++ b/src/modules/tensor/cpu/kernel/threshold.cpp
@@ -128,7 +128,7 @@ RppStatus threshold_u8_u8_host_tensor(Rpp8u *srcPtr,
                 dstPtrTempB = dstPtrRowB;
                 int vectorLoopCount = 0;
 #if __AVX2__
-                for (; vectorLoopCount < alignedLength; vectorLoopCount += 16)
+                for (; vectorLoopCount < alignedLength; vectorLoopCount += 48)
                 {
                     __m256 p[6];
                     rpp_simd_load(rpp_load48_u8pkd3_to_f32pln3_avx, srcPtrTemp, p);                               // simd loads
@@ -427,7 +427,7 @@ RppStatus threshold_f32_f32_host_tensor(Rpp32f *srcPtr,
                 dstPtrTempB = dstPtrRowB;
                 int vectorLoopCount = 0;
 #if __AVX2__
-                for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
+                for (; vectorLoopCount < alignedLength; vectorLoopCount += 24)
                 {
                     __m256 p[3];
                     rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp, p);                               // simd loads
@@ -726,7 +726,7 @@ RppStatus threshold_i8_i8_host_tensor(Rpp8s *srcPtr,
                 dstPtrTempB = dstPtrRowB;
                 int vectorLoopCount = 0;
 #if __AVX2__
-                for (; vectorLoopCount < alignedLength; vectorLoopCount += 16)
+                for (; vectorLoopCount < alignedLength; vectorLoopCount += 48)
                 {
                     __m256 p[6];
                     rpp_simd_load(rpp_load48_i8pkd3_to_f32pln3_avx, srcPtrTemp, p);                               // simd loads
@@ -1025,7 +1025,7 @@ RppStatus threshold_f16_f16_host_tensor(Rpp16f *srcPtr,
                 dstPtrTempB = dstPtrRowB;
                 int vectorLoopCount = 0;
 #if __AVX2__
-                for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
+                for (; vectorLoopCount < alignedLength; vectorLoopCount += 24)
                 {
                     __m256 p[3];
                     rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);                               // simd loads

--- a/src/modules/tensor/cpu/kernel/water.cpp
+++ b/src/modules/tensor/cpu/kernel/water.cpp
@@ -867,7 +867,7 @@ RppStatus water_i8_i8_host_tensor(Rpp8s *srcPtr,
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
                     __m256 pCosFactor, pDummy, pSrcX, pSrcY;
-                    __m256i pRow[3];
+                    __m256i pRow[4];
                     sincos_ps(_mm256_fmadd_ps(pWaterParams[3], pDstX, pWaterParams[5]), &pDummy, &pCosFactor);
                     compute_water_src_loc_avx(pDstY, pDstX, pSrcY, pSrcX, pWaterParams, pSinFactor, pCosFactor, pRoiLTRB[3], pRoiLTRB[2], pSrcStrideH, srcLocArray);
                     compute_generic_nn_srclocs_and_validate_avx(pSrcY, pSrcX, pRoiLTRB, pSrcStrideH, srcLocArray, invalidLoad);
@@ -882,6 +882,7 @@ RppStatus water_i8_i8_host_tensor(Rpp8s *srcPtr,
                     Rpp32f srcX, srcY, cosFactor;
                     dstX = vectorLoopCount;
                     cosFactor = std::cos((freqY * dstX) + phaseY);
+                    compute_water_src_loc(dstY, dstX, srcY, srcX, amplY, amplX, sinFactor, cosFactor, &roiLTRB);
                     compute_generic_nn_interpolation_pln3_to_pkd3(srcY, srcX, &roiLTRB, dstPtrTemp, srcPtrChannel, srcDescPtr);
                     dstPtrTemp += 3;
                 }
@@ -977,9 +978,7 @@ RppStatus water_i8_i8_host_tensor(Rpp8s *srcPtr,
                     dstX = vectorLoopCount;
                     cosFactor = std::cos((freqY * dstX) + phaseY);
                     compute_water_src_loc(dstY, dstX, srcY, srcX, amplY, amplX, sinFactor, cosFactor, &roiLTRB);
-
-                    for(int i = 0; i < srcDescPtr->c; i++)
-                        compute_generic_nn_interpolation_pln_to_pln(srcY, srcX, &roiLTRB, dstPtrTemp++, srcPtrChannel, srcDescPtr, dstDescPtr);
+                    compute_generic_nn_interpolation_pln_to_pln(srcY, srcX, &roiLTRB, dstPtrTemp++, srcPtrChannel, srcDescPtr, dstDescPtr);
                 }
                 dstPtrRow += dstDescPtr->strides.hStride;
             }

--- a/utilities/test_suite/HIP/Tensor_image_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_image_hip.cpp
@@ -105,24 +105,24 @@ int main(int argc, char **argv)
         if(testCase == COLOR_TWIST || testCase == COLOR_CAST || testCase == GLITCH || testCase == COLOR_TEMPERATURE || testCase == COLOR_TO_GREYSCALE)
         {
             cout << "\ncase " << testCase << " does not exist for PLN1 layout\n";
-            return -1;
+            return RPP_ERROR_NOT_IMPLEMENTED;
         }
         else if (outputFormatToggle != 0)
         {
             cout << "\nPLN1 cases don't have outputFormatToggle! Please input outputFormatToggle = 0\n";
-            return -1;
+            return RPP_ERROR_NOT_IMPLEMENTED;
         }
     }
 
     if(pln1OutTypeCase && outputFormatToggle != 0)
     {
         cout << "\ntest case " << testCase << " don't have outputFormatToggle! Please input outputFormatToggle = 0\n";
-        return -1;
+        return RPP_ERROR_NOT_IMPLEMENTED;
     }
     else if (reductionTypeCase && outputFormatToggle != 0)
     {
         cout << "\nReduction Kernels don't have outputFormatToggle! Please input outputFormatToggle = 0\n";
-        return -1;
+        return RPP_ERROR_NOT_IMPLEMENTED;
     }
     else if(batchSize > MAX_BATCH_SIZE)
     {

--- a/utilities/test_suite/HIP/runImageTests.py
+++ b/utilities/test_suite/HIP/runImageTests.py
@@ -313,6 +313,9 @@ if(testType == 0):
         if imageAugmentationMap[int(case)][0] == "lens_correction" and (("--input_path1" not in sys.argv and "--input_path2" not in sys.argv) or qaMode == 1):
             srcPath1 = lensCorrectionInFilePath
             srcPath2 = lensCorrectionInFilePath
+        else:
+            srcPath1 = inFilePath1
+            srcPath2 = inFilePath2
         # if QA mode is enabled overwrite the input folders with the folders used for generating golden outputs
         if qaMode == 1 and (imageAugmentationMap[int(case)][0] not in {"ricap", "lens_correction"}):
             srcPath1 = inFilePath1
@@ -343,6 +346,9 @@ else:
             if imageAugmentationMap[int(case)][0] == "lens_correction" and "--input_path1" not in sys.argv and "--input_path2" not in sys.argv:
                 srcPath1 = lensCorrectionInFilePath
                 srcPath2 = lensCorrectionInFilePath
+            else:
+                srcPath1 = inFilePath1
+                srcPath2 = inFilePath2
             for layout in range(3):
                 dstPathTemp, logFileLayout = process_layout(layout, qaMode, case, dstPath, "hip", func_group_finder)
 
@@ -363,6 +369,9 @@ else:
             if imageAugmentationMap[int(case)][0] == "lens_correction" and "--input_path1" not in sys.argv and "--input_path2" not in sys.argv:
                 srcPath1 = lensCorrectionInFilePath
                 srcPath2 = lensCorrectionInFilePath
+            else:
+                srcPath1 = inFilePath1
+                srcPath2 = inFilePath2
             for layout in range(3):
                 dstPathTemp, logFileLayout = process_layout(layout, qaMode, case, dstPath, "hip", func_group_finder)
 

--- a/utilities/test_suite/HOST/Tensor_image_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_image_host.cpp
@@ -104,24 +104,24 @@ int main(int argc, char **argv)
         if(testCase == COLOR_CAST || testCase == GLITCH || testCase == COLOR_TWIST || testCase == COLOR_TEMPERATURE || testCase == COLOR_TO_GREYSCALE)
         {
             cout << "\ncase " << testCase << " does not exist for PLN1 layout\n";
-            return -1;
+            return RPP_ERROR_NOT_IMPLEMENTED;
         }
         else if (outputFormatToggle != 0)
         {
             cout << "\nPLN1 cases don't have outputFormatToggle! Please input outputFormatToggle = 0\n";
-            return -1;
+            return RPP_ERROR_NOT_IMPLEMENTED;
         }
     }
 
     if(pln1OutTypeCase && outputFormatToggle != 0)
     {
         cout << "\ntest case " << testCase << " don't have outputFormatToggle! Please input outputFormatToggle = 0\n";
-        return -1;
+        return RPP_ERROR_NOT_IMPLEMENTED;
     }
     else if (reductionTypeCase && outputFormatToggle != 0)
     {
         cout << "\nReduction Kernels don't have outputFormatToggle! Please input outputFormatToggle = 0\n";
-        return -1;
+        return RPP_ERROR_NOT_IMPLEMENTED;
     }
     else if(batchSize > MAX_BATCH_SIZE)
     {

--- a/utilities/test_suite/HOST/runImageTests.py
+++ b/utilities/test_suite/HOST/runImageTests.py
@@ -292,9 +292,12 @@ if testType == 0:
         if imageAugmentationMap[int(case)][0] == "ricap" and (("--input_path1" not in sys.argv and "--input_path2" not in sys.argv) or qaMode == 1):
             srcPath1 = ricapInFilePath
             srcPath2 = ricapInFilePath
-        if imageAugmentationMap[int(case)][0] == "lens_correction" and (("--input_path1" not in sys.argv and "--input_path2" not in sys.argv) or qaMode == 1):
+        elif imageAugmentationMap[int(case)][0] == "lens_correction" and (("--input_path1" not in sys.argv and "--input_path2" not in sys.argv) or qaMode == 1):
             srcPath1 = lensCorrectionInFilePath
             srcPath2 = lensCorrectionInFilePath
+        else:
+            srcPath1 = inFilePath1
+            srcPath2 = inFilePath2
         # if QA mode is enabled overwrite the input folders with the folders used for generating golden outputs
         if qaMode == 1 and (imageAugmentationMap[int(case)][0] not in {"ricap", "lens_correction"}):
             srcPath1 = inFilePath1
@@ -319,15 +322,20 @@ else:
         if int(case) not in imageAugmentationMap:
             continue
         # if QA mode is enabled overwrite the input folders with the folders used for generating golden outputs
-        if qaMode == 1 and imageAugmentationMap[int(case)][0] != "ricap":
+        func_name = imageAugmentationMap[int(case)][0]
+
+        if qaMode == 1 and func_name != "ricap":
             srcPath1 = inFilePath1
             srcPath2 = inFilePath2
-        if imageAugmentationMap[int(case)][0] == "ricap" and "--input_path1" not in sys.argv and "--input_path2" not in sys.argv:
+        elif func_name == "ricap" and "--input_path1" not in sys.argv and "--input_path2" not in sys.argv:
             srcPath1 = ricapInFilePath
             srcPath2 = ricapInFilePath
-        if imageAugmentationMap[int(case)][0] == "lens_correction" and "--input_path1" not in sys.argv and "--input_path2" not in sys.argv:
+        elif func_name == "lens_correction" and "--input_path1" not in sys.argv and "--input_path2" not in sys.argv:
             srcPath1 = lensCorrectionInFilePath
             srcPath2 = lensCorrectionInFilePath
+        else:
+            srcPath1 = inFilePath1
+            srcPath2 = inFilePath2
         for layout in range(3):
             dstPathTemp, logFileLayout = process_layout(layout, qaMode, case, dstPath, "host", func_group_finder)
             run_performance_test(loggingFolder, logFileLayout, srcPath1, srcPath2, dstPath, case, numRuns, testType, layout, qaMode, decoderType, batchSize, roiList)

--- a/utilities/test_suite/common.py
+++ b/utilities/test_suite/common.py
@@ -129,7 +129,7 @@ miscAugmentationMap  = {
 ImageAugmentationGroupMap = {
     "color_augmentations" : [0, 1, 2, 3, 4, 13, 31, 34, 36, 45, 81],
     "effects_augmentations" : [5, 6, 8, 10, 11, 29, 30, 32, 35, 46, 82, 83, 84],
-    "geometric_augmentations" : [20, 21, 23, 24, 26, 28, 33, 37, 38, 39, 63, 79, 80, 92],
+    "geometric_augmentations" : [20, 21, 23, 24, 26, 28, 33, 37, 38, 39, 63, 79, 80, 92, 93],
     "filter_augmentations" : [40, 41, 49, 54],
     "arithmetic_operations" : [61],
     "logical_operations" : [65, 66, 67, 68],


### PR DESCRIPTION
Adds minor bugfixes and some test suite mods:
- Returns a specific category of RPP_ERROR enum instead of a generic "RPP_ERROR" return. (Now returns RPP_ERROR_NOT_IMPLEMENTED if the function variant requested isn't implemented or doesn't exist.
- Fixes for issues in threshold_f32_Tensor_HOST_PKD3_toPLN3 and flip_f16_Tensor_HOST_PLN3_toPLN3 revealed by RHEL8.
- Minor fixes for mem related issues in filters.
- Fix for unit test to use the standard small images consistently across all unit tests with exception of certain functionalities like lens correction that need a different image to visualize outputs easily.